### PR TITLE
adding gibraltar to domestic countries

### DIFF
--- a/src/invoice.js
+++ b/src/invoice.js
@@ -316,7 +316,7 @@ const priceFormatters = {
 
 handlebars.registerHelper('formatPrice', (value, currency) => priceFormatters[currency].format(value))
 
-const domesticCountries = ['The United States of America', 'United Kingdom']
+const domesticCountries = ['The United States of America', 'United Kingdom', 'Gibraltar']
 
 export const isDomestic = (vendorCountry, clientCountry) =>
   vendorCountry === clientCountry ||


### PR DESCRIPTION
Adding Gibraltar to domestic countries to exclude it from list of countries which have - **'The delivery of service takes place in a different EU member state. The person responsible for tax payment is the recipient.'** sentence on invoice.